### PR TITLE
Upgrade Inversify to version 7.0.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1096,14 +1096,14 @@
     },
     "node_modules/@inversifyjs/common": {
       "version": "1.5.0",
-      "resolved": "https://lpe.jfrog.io/artifactory/api/npm/lpe-shared-npm-prd-virtual/@inversifyjs/common/-/common-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/common/-/common-1.5.0.tgz",
       "integrity": "sha512-Qj5BELk11AfI2rgZEAaLPmOftmQRLLmoCXgAjmaF0IngQN5vHomVT5ML7DZ3+CA5fgGcEVMcGbUDAun+Rz+oNg==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@inversifyjs/container": {
       "version": "1.5.4",
-      "resolved": "https://lpe.jfrog.io/artifactory/api/npm/lpe-shared-npm-prd-virtual/@inversifyjs/container/-/container-1.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/container/-/container-1.5.4.tgz",
       "integrity": "sha512-mHAaWjAQb8m6TJksm5EJXW/kPcZFVEc1UKkWv5OnLbwbU0QvxM2UbEsuXzusGVHcrNY4TQp9Uh2wkRY6TN2WJg==",
       "license": "MIT",
       "peer": true,
@@ -1118,7 +1118,7 @@
     },
     "node_modules/@inversifyjs/core": {
       "version": "5.0.0",
-      "resolved": "https://lpe.jfrog.io/artifactory/api/npm/lpe-shared-npm-prd-virtual/@inversifyjs/core/-/core-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/core/-/core-5.0.0.tgz",
       "integrity": "sha512-axOl+VZFGVA3nAMbs6RuHhQ8HvgO6/tKjlWJk4Nt0rUqed+1ksak4p5yZNtown1Kdm0GV2Oc57qLqqWd943hgA==",
       "license": "MIT",
       "peer": true,
@@ -1130,7 +1130,7 @@
     },
     "node_modules/@inversifyjs/prototype-utils": {
       "version": "0.1.0",
-      "resolved": "https://lpe.jfrog.io/artifactory/api/npm/lpe-shared-npm-prd-virtual/@inversifyjs/prototype-utils/-/prototype-utils-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/prototype-utils/-/prototype-utils-0.1.0.tgz",
       "integrity": "sha512-lNz1yyajMRDXBHLvJsYYX81FcmeD15e5Qz1zAZ/3zeYTl+u7ZF/GxNRKJzNOloeMPMtuR8BnvzHA1SZxjR+J9w==",
       "license": "MIT",
       "peer": true,
@@ -1140,7 +1140,7 @@
     },
     "node_modules/@inversifyjs/reflect-metadata-utils": {
       "version": "1.1.0",
-      "resolved": "https://lpe.jfrog.io/artifactory/api/npm/lpe-shared-npm-prd-virtual/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-1.1.0.tgz",
       "integrity": "sha512-jmuAuC3eL1GnFAYfJGJOMKRDL9q1mgzOyrban6zxfM8Yg1FUHsj25h27bW2G7p8X1Amvhg3MLkaOuogszkrofA==",
       "license": "MIT",
       "peer": true,
@@ -5928,7 +5928,7 @@
     },
     "node_modules/inversify": {
       "version": "7.1.0",
-      "resolved": "https://lpe.jfrog.io/artifactory/api/npm/lpe-shared-npm-prd-virtual/inversify/-/inversify-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-7.1.0.tgz",
       "integrity": "sha512-f8SlUTgecMZGr/rsFK36PD84/mH0+sp0/P/TuiGo3CcJywmF5kgoXeE2RW5IjaIt1SlqS5c5V9RuQc1+B8mw4Q==",
       "license": "MIT",
       "peer": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "conventional-changelog-cli": "^5.0.0",
         "cz-conventional-changelog": "^3.3.0",
         "eslint": "^9.14.0",
+        "inversify": "^7.2.0",
         "jest": "^29.7.0",
         "jest-cli": "^29.5.0",
         "nodemon": "^3.0.1",
@@ -34,7 +35,7 @@
         "yargs": "^17.7.2"
       },
       "peerDependencies": {
-        "inversify": "^7.0.0"
+        "inversify": "^7.2.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -266,27 +267,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.10"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.0"
+        "@babel/types": "^7.26.10"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -535,15 +536,15 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -579,9 +580,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1098,18 +1099,18 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@inversifyjs/common/-/common-1.5.0.tgz",
       "integrity": "sha512-Qj5BELk11AfI2rgZEAaLPmOftmQRLLmoCXgAjmaF0IngQN5vHomVT5ML7DZ3+CA5fgGcEVMcGbUDAun+Rz+oNg==",
-      "license": "MIT",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@inversifyjs/container": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@inversifyjs/container/-/container-1.5.4.tgz",
-      "integrity": "sha512-mHAaWjAQb8m6TJksm5EJXW/kPcZFVEc1UKkWv5OnLbwbU0QvxM2UbEsuXzusGVHcrNY4TQp9Uh2wkRY6TN2WJg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/container/-/container-1.6.0.tgz",
+      "integrity": "sha512-dntAu6TJRmTJl8+VXksBmvpfNtXQAEG6DkcdwOyv6xIr4ASdMdG2+14XKY5xUX8luk3CDCnK0j5XM8uxROfWuw==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inversifyjs/common": "1.5.0",
-        "@inversifyjs/core": "5.0.0",
+        "@inversifyjs/core": "5.1.0",
         "@inversifyjs/reflect-metadata-utils": "1.1.0"
       },
       "peerDependencies": {
@@ -1117,11 +1118,11 @@
       }
     },
     "node_modules/@inversifyjs/core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@inversifyjs/core/-/core-5.0.0.tgz",
-      "integrity": "sha512-axOl+VZFGVA3nAMbs6RuHhQ8HvgO6/tKjlWJk4Nt0rUqed+1ksak4p5yZNtown1Kdm0GV2Oc57qLqqWd943hgA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/core/-/core-5.1.0.tgz",
+      "integrity": "sha512-mxawKEUmRAwQeNGymf2WucPNEnyWnaGMTi2cOyIq9/zqMbo8LpXh8OFkGvJciFWznC6fDnP27O80u+sY/JjU9g==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inversifyjs/common": "1.5.0",
         "@inversifyjs/prototype-utils": "0.1.0",
@@ -1132,8 +1133,8 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@inversifyjs/prototype-utils/-/prototype-utils-0.1.0.tgz",
       "integrity": "sha512-lNz1yyajMRDXBHLvJsYYX81FcmeD15e5Qz1zAZ/3zeYTl+u7ZF/GxNRKJzNOloeMPMtuR8BnvzHA1SZxjR+J9w==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inversifyjs/common": "1.5.0"
       }
@@ -1142,8 +1143,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-1.1.0.tgz",
       "integrity": "sha512-jmuAuC3eL1GnFAYfJGJOMKRDL9q1mgzOyrban6zxfM8Yg1FUHsj25h27bW2G7p8X1Amvhg3MLkaOuogszkrofA==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "reflect-metadata": "0.2.2"
       }
@@ -5927,15 +5928,15 @@
       }
     },
     "node_modules/inversify": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/inversify/-/inversify-7.1.0.tgz",
-      "integrity": "sha512-f8SlUTgecMZGr/rsFK36PD84/mH0+sp0/P/TuiGo3CcJywmF5kgoXeE2RW5IjaIt1SlqS5c5V9RuQc1+B8mw4Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-7.2.0.tgz",
+      "integrity": "sha512-zPXKp7ybicPsrhlNZaJscZ9yeg0DZtnCGuNfMpMsso9Jx1tNepSS2CqPrrP8Pc75nH/5d/qB2rYKiv1BEI1gFQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inversifyjs/common": "1.5.0",
-        "@inversifyjs/container": "1.5.4",
-        "@inversifyjs/core": "5.0.0"
+        "@inversifyjs/container": "1.6.0",
+        "@inversifyjs/core": "5.1.0"
       },
       "peerDependencies": {
         "reflect-metadata": "~0.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "yargs": "^17.7.2"
       },
       "peerDependencies": {
-        "inversify": "^6.0.3"
+        "inversify": "^7.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1092,6 +1092,60 @@
       "dev": true,
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@inversifyjs/common": {
+      "version": "1.5.0",
+      "resolved": "https://lpe.jfrog.io/artifactory/api/npm/lpe-shared-npm-prd-virtual/@inversifyjs/common/-/common-1.5.0.tgz",
+      "integrity": "sha512-Qj5BELk11AfI2rgZEAaLPmOftmQRLLmoCXgAjmaF0IngQN5vHomVT5ML7DZ3+CA5fgGcEVMcGbUDAun+Rz+oNg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@inversifyjs/container": {
+      "version": "1.5.4",
+      "resolved": "https://lpe.jfrog.io/artifactory/api/npm/lpe-shared-npm-prd-virtual/@inversifyjs/container/-/container-1.5.4.tgz",
+      "integrity": "sha512-mHAaWjAQb8m6TJksm5EJXW/kPcZFVEc1UKkWv5OnLbwbU0QvxM2UbEsuXzusGVHcrNY4TQp9Uh2wkRY6TN2WJg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@inversifyjs/common": "1.5.0",
+        "@inversifyjs/core": "5.0.0",
+        "@inversifyjs/reflect-metadata-utils": "1.1.0"
+      },
+      "peerDependencies": {
+        "reflect-metadata": "~0.2.2"
+      }
+    },
+    "node_modules/@inversifyjs/core": {
+      "version": "5.0.0",
+      "resolved": "https://lpe.jfrog.io/artifactory/api/npm/lpe-shared-npm-prd-virtual/@inversifyjs/core/-/core-5.0.0.tgz",
+      "integrity": "sha512-axOl+VZFGVA3nAMbs6RuHhQ8HvgO6/tKjlWJk4Nt0rUqed+1ksak4p5yZNtown1Kdm0GV2Oc57qLqqWd943hgA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@inversifyjs/common": "1.5.0",
+        "@inversifyjs/prototype-utils": "0.1.0",
+        "@inversifyjs/reflect-metadata-utils": "1.1.0"
+      }
+    },
+    "node_modules/@inversifyjs/prototype-utils": {
+      "version": "0.1.0",
+      "resolved": "https://lpe.jfrog.io/artifactory/api/npm/lpe-shared-npm-prd-virtual/@inversifyjs/prototype-utils/-/prototype-utils-0.1.0.tgz",
+      "integrity": "sha512-lNz1yyajMRDXBHLvJsYYX81FcmeD15e5Qz1zAZ/3zeYTl+u7ZF/GxNRKJzNOloeMPMtuR8BnvzHA1SZxjR+J9w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@inversifyjs/common": "1.5.0"
+      }
+    },
+    "node_modules/@inversifyjs/reflect-metadata-utils": {
+      "version": "1.1.0",
+      "resolved": "https://lpe.jfrog.io/artifactory/api/npm/lpe-shared-npm-prd-virtual/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-1.1.0.tgz",
+      "integrity": "sha512-jmuAuC3eL1GnFAYfJGJOMKRDL9q1mgzOyrban6zxfM8Yg1FUHsj25h27bW2G7p8X1Amvhg3MLkaOuogszkrofA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "reflect-metadata": "0.2.2"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -5873,11 +5927,19 @@
       }
     },
     "node_modules/inversify": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/inversify/-/inversify-6.0.3.tgz",
-      "integrity": "sha512-s/svzcRQ/scaGUUyaVtFSL1dvOaRgyvE7VvpGcJwXmFz7CCzfSfxC/Uyl7iSHDEmBabJ2gbDES72DaygtMmwvg==",
+      "version": "7.1.0",
+      "resolved": "https://lpe.jfrog.io/artifactory/api/npm/lpe-shared-npm-prd-virtual/inversify/-/inversify-7.1.0.tgz",
+      "integrity": "sha512-f8SlUTgecMZGr/rsFK36PD84/mH0+sp0/P/TuiGo3CcJywmF5kgoXeE2RW5IjaIt1SlqS5c5V9RuQc1+B8mw4Q==",
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "dependencies": {
+        "@inversifyjs/common": "1.5.0",
+        "@inversifyjs/container": "1.5.4",
+        "@inversifyjs/core": "5.0.0"
+      },
+      "peerDependencies": {
+        "reflect-metadata": "~0.2.2"
+      }
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "postversion": "git push && git push --tags",
     "prepare": "npm run build",
     "test": "run-s test:*",
-    "test:lint": "eslint --ext .ts --fix src/**/*.ts test/**/*.ts",
+    "test:lint": "npx eslint --ext .ts --fix src/**/*.ts test/**/*.ts",
     "test:unit": "jest",
     "upgrade": "npx npm-check -u",
     "version": "npm run build && npm run changelog:update"
@@ -63,7 +63,7 @@
     }
   },
   "peerDependencies": {
-    "inversify": "^6.0.3"
+    "inversify": "^7.0.0"
   },
   "dependencies": {
     "class-transformer": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.1",
     "typescript": "^5.6.3",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "inversify": "^7.2.0"
   },
   "config": {
     "commitizen": {
@@ -63,7 +64,7 @@
     }
   },
   "peerDependencies": {
-    "inversify": "^7.0.0"
+    "inversify": "^7.2.0"
   },
   "dependencies": {
     "class-transformer": "^0.5.1",

--- a/src/container/lambda-handler-helper-container.ts
+++ b/src/container/lambda-handler-helper-container.ts
@@ -1,4 +1,4 @@
-import { Container, interfaces } from 'inversify';
+import { Container, Newable } from 'inversify';
 import { ILogger } from '../loggers';
 import { CONTAINERTYPES } from './container-types';
 import { DefaultLogger } from '../loggers/default.logger';
@@ -6,7 +6,7 @@ import { IEventHandler } from '../lambda/event-handler.interface';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class LambdaHandlerHelperContainer<EventHandler extends IEventHandler<any,any>> extends Container {
-	constructor(handler : interfaces.Newable<EventHandler>) {
+	constructor(handler : Newable<EventHandler>) {
 		super();
 
 		this.bind<ILogger>(CONTAINERTYPES.ILogger).to(DefaultLogger);

--- a/src/lambda/lambda-handler-helper.ts
+++ b/src/lambda/lambda-handler-helper.ts
@@ -64,8 +64,11 @@ export class LambdaHandlerHelper<InputMessage, OutputMessage = void> {
 
 			const result = await Promise.all(
 				events.map(async (eventSet): Promise<OutputMessage | undefined> => {
+					let logger : ILogger = this.logger;
+					let scopedContainer : Container | undefined = undefined;
 					try {
-						const scopedContainer = new Container({ parent: this.container});
+						scopedContainer = new Container({ parent: this.container});
+						logger = scopedContainer.get<ILogger>(CONTAINERTYPES.ILogger);
 						scopedContainer
 							.bind<string>(CONTAINERTYPES.EventId)
 							.toConstantValue(eventSet.eventId);
@@ -83,15 +86,18 @@ export class LambdaHandlerHelper<InputMessage, OutputMessage = void> {
 							eventSet.eventId
 						);
 					} catch (error) {
-						this.logger.log(LogLevel.ERROR, {
+						logger.log(LogLevel.ERROR, {
 							Error: inspect(error, { depth: null }),
 							event: eventSet.event,
 						});
-						failedMessages.push({ kind: eventSet, error: error as Error });
+						failedMessages.push({ kind: eventSet, error: error as Error });						
 					} finally {
-						const logger = this.container.get<ILogger>(CONTAINERTYPES.ILogger);
-						if (isDisposable(logger)) {
-							logger.dispose();
+						if (scopedContainer !== undefined) {
+							// should move this disposing
+							const logger = this.container.get<ILogger>(CONTAINERTYPES.ILogger);
+							if (isDisposable(logger)) {
+								logger.dispose();
+							}
 						}
 					}
 					return undefined;

--- a/src/lambda/lambda-handler-helper.ts
+++ b/src/lambda/lambda-handler-helper.ts
@@ -28,6 +28,7 @@ import { FailedMessages } from './failed-messages';
 import { isDisposable } from '../disposable.interface';
 import { validateAndConvertDTO } from '../validation/validation';
 import { ValidationException } from '../validation/validation-exception';
+import { Container } from 'inversify';
 
 // Define the base class with a generic type for the message
 export class LambdaHandlerHelper<InputMessage, OutputMessage = void> {
@@ -64,7 +65,7 @@ export class LambdaHandlerHelper<InputMessage, OutputMessage = void> {
 			const result = await Promise.all(
 				events.map(async (eventSet): Promise<OutputMessage | undefined> => {
 					try {
-						const scopedContainer = this.container.createChild();
+						const scopedContainer = new Container({ parent: this.container});
 						scopedContainer
 							.bind<string>(CONTAINERTYPES.EventId)
 							.toConstantValue(eventSet.eventId);

--- a/src/loggers/default.logger.ts
+++ b/src/loggers/default.logger.ts
@@ -28,11 +28,11 @@ export class DefaultLogger implements ILogger, IDisposable {
 	log(level: LogLevel, message: any): void {
 		const newMessage = { eventId: this.eventId, message, logLevel: level };
 		if (isLogLevelGreaterThanOrEqual(level, this.logLevel)) {
-			this.logMessage(newMessage);
-			// log the rest as well
+			// log the older messages first
 			this.storedLines.forEach((line) => {
 				this.logMessage(line);
 			});
+			this.logMessage(newMessage);
 			this.clearMessage();
 		} else if (isLogLevelGreaterThanOrEqual(level, LogLevel.INFO)) {
 			// we dont want to default store trace logs

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "resolveJsonModule": true,                /* Include modules imported with '.json' extension. Requires TypeScript version 2.9 or later. */
 
     /* Basic Options */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "target": "ES2021",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": ["es5", "es6"],                    /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,6 +57,8 @@
     // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
     // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
+    "skipDefaultLibCheck": true,
+    "skipLibCheck": true,
     /* Experimental Options */
     "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */


### PR DESCRIPTION
Upgrade the Inversify dependency to version 7.0.0 and adjust related code to accommodate changes in the library's API. Update TypeScript target to ES2021 for improved compatibility.